### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#RedisStudio (Redis GUI Client)
+# RedisStudio (Redis GUI Client)
 
 ## Download
 [![GitHub release](https://img.shields.io/github/release/cinience/RedisStudio.svg?style=flat-square)](https://github.com/cinience/RedisStudio/releases) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
